### PR TITLE
URA-793 eggd rnaseqc v1.1.1

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -77,7 +77,8 @@
       "patterns": [
         "*"
       ],
-      "help": "A list of fragment sizes recorded."
+      "help": "A list of fragment sizes recorded.",
+      "optional": true
     },
     {
       "name": "gene_fragments",
@@ -85,8 +86,10 @@
       "patterns": [
         "*"
       ],
-      "help": "Number of fragment sizes per gene."
-    },{
+      "help": "Number of fragment sizes per gene.",
+      "optional": true
+    },
+    {
       "name": "gene_reads",
       "class": "file",
       "patterns": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -2,8 +2,8 @@
   "name": "eggd_RNASeQC",
   "title": "eggd_RNASeQC",
   "summary": "Calculates QC metrics for RNA BAM files",
-  "dxapi": "1.1.0",
-  "version": "1.1.0",
+  "dxapi": "1.0.0",
+  "version": "1.1.1",
   "authorizedUsers": [
     "org-emee_1"
   ],

--- a/src/eggd_RNASeQC.sh
+++ b/src/eggd_RNASeQC.sh
@@ -84,6 +84,26 @@ main() {
         echo "No coverage reports generated as coverage option was not selected"
     fi
 
+    # If fragmentSizes is made, then it needs to be outputted as well
+    if [ -f *fragmentSizes.txt ]; then
+        echo "fragmentSizes.txt exists."
+        mkdir -p fragmentSizes
+
+        mv *fragmentSizes.txt /home/dnanexus/out/fragmentSizes/
+    else
+        echo "No fragmentSizes generated"
+    fi
+
+    # If gene_fragments is made, then it needs to be outputted as well  
+    if [ -f *gene_fragments.gct ]; then
+        echo "gene_fragments.gct exists."
+        mkdir -p gene_fragments
+
+        mv *gene_fragments.gct /home/dnanexus/out/gene_fragments/
+    else
+        echo "No gene_fragments generated"
+    fi
+
     dx-upload-all-outputs
 
 }

--- a/src/eggd_RNASeQC.sh
+++ b/src/eggd_RNASeQC.sh
@@ -20,7 +20,7 @@ main() {
     docker load -i "${docker}"
 
     # Get image id from docker image loaded
-    IMAGE_ID=$(sudo docker images --format="{{.Repository}} {{.ID}}" | grep "^gcr" | cut -d' ' -f2)
+    IMAGE_ID=$(sudo docker images --format="{{.Repository}} {{.ID}}" | grep "rnaseq" | cut -d' ' -f2)
 
 
     echo "---------- Decompress CTAT bundle -------------"

--- a/src/eggd_RNASeQC.sh
+++ b/src/eggd_RNASeQC.sh
@@ -63,12 +63,10 @@ main() {
 
     echo "--------------Outputting files -----------------"
     cd /home/dnanexus/out/
-    mkdir -p exon_cv exon_reads fragmentSizes gene_fragments gene_reads gene_tpm metrics
+    mkdir -p exon_cv exon_reads gene_reads gene_tpm metrics
 
     mv *exon_cv.tsv /home/dnanexus/out/exon_cv/
     mv *exon_reads.gct /home/dnanexus/out/exon_reads/
-    mv *fragmentSizes.txt /home/dnanexus/out/fragmentSizes/
-    mv *gene_fragments.gct /home/dnanexus/out/gene_fragments/
     mv *gene_reads.gct /home/dnanexus/out/gene_reads/
     mv *gene_tpm.gct /home/dnanexus/out/gene_tpm/
     mv *metrics.tsv /home/dnanexus/out/metrics/


### PR DESCRIPTION
- Have fragment sizes as optional outputs
- Update to string search the rnaseqc docker image

Job that works with the correct rnaseqc docker image & does not generate the optional outputs (FragmentSizes) : https://platform.dnanexus.com/panx/projects/GjQY0F04099v2p7zX2Y217VF/monitor/job/Gp2ZVx04099zyg26JVB19jJg

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_RNASeQC/8)
<!-- Reviewable:end -->
